### PR TITLE
fix: add missing dependency on `@adonisjs/http-server`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@adonisjs/auth": "^9.0.2",
     "@adonisjs/core": "^6.2.1",
+    "@adonisjs/http-server": "^7.0.2",
     "@adonisjs/lucid": "^19.0.0",
     "@adonisjs/session": "^7.1.1",
     "@adonisjs/shield": "^8.1.0",


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### Description

I spinned up a new v6 project to try out Adonis. The `app/exceptions/handler.ts` file uses `@adonisjs/http-server`, which was not included in the starter kit, so there were type errors (and probably runtime errors if I ran the code?).

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
