### PR TITLE
Adding dumper stack to home page

### DIFF
--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -65,6 +65,7 @@
     </script>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @stack('dumper')
   </head>
   <body class="min-h-screen w-screen font-sans">
     <div


### PR DESCRIPTION
### 🔗 Linked issue

Related Discussion: https://github.com/orgs/adonisjs/discussions/4844

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adding `@stack('dumper')` to the EdgeJS home page so that the script & styles get added out-of-the-box when using the `@dump` helper.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
